### PR TITLE
Fix dependency declaration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,6 @@ classifiers = [
 ]
 
 dependencies = [
-    "requests=^2.31.0",
-    "xmltodict=^0.12.0",
+    "requests >= 2.31.0, < 3",
+    "xmltodict >= 0.12.0, < 1",
 ]


### PR DESCRIPTION
Seems that PEP 631 doesn't support the `^` for versions. That's what I get for trusting copilot.