### PR TITLE
Expand response handling more

### DIFF
--- a/src/nmigate/customer/billing_record.py
+++ b/src/nmigate/customer/billing_record.py
@@ -28,7 +28,9 @@ class BillingRecord(Nmi):
 
     def add(self, payment_token, billing_info):
         if not self.billing_id:
-            self.billing_id = str(uuid.uuid4())
+            # API does not state a max, but including hyphens failed with "too long".
+            # The hex version appears to work, though.
+            self.billing_id = uuid.uuid4().hex
 
         data = self._create_data(
             "add_billing",

--- a/src/nmigate/customer/customer_vault.py
+++ b/src/nmigate/customer/customer_vault.py
@@ -31,9 +31,9 @@ class CustomerVault(Nmi):
         billing_id=None,
     ):
         if not self.customer_id:
-            self.customer_id = str(uuid.uuid4())
+            self.customer_id = uuid.uuid4().hex
 
-        self.billing_id = billing_id or str(uuid.uuid4())
+        self.billing_id = billing_id or uuid.uuid4().hex
 
         data = self._create_data(
             "add_customer",
@@ -52,7 +52,7 @@ class CustomerVault(Nmi):
 
     def charge(self, amount, initial_transaction_id, initiated_by_customer=False):
         if not self.customer_id:
-            self.customer_id = str(uuid.uuid4())
+            self.customer_id = uuid.uuid4().hex
 
         data = {
             "security_key": self.security_key,

--- a/src/nmigate/exceptions.py
+++ b/src/nmigate/exceptions.py
@@ -1,0 +1,86 @@
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import HTTPError as RequestsHTTPError
+from requests.exceptions import RequestException
+
+""" Custom exceptions for the NMI gateway, based on requests exceptions. """
+
+
+class APIException(RequestException):
+    pass
+
+
+class ConnectionError(APIException, RequestsConnectionError):
+    """
+    Connection issues with the API.
+    """
+
+
+class HTTPError(APIException, RequestsHTTPError):
+    """
+    HTTP error status code returned by the API.
+
+    All responses should return 200 except some rate limit
+    issues, so this shouldn't generally occur.
+    """
+
+
+class ResponseError(APIException):
+    """
+    Error found in the response data.
+    """
+
+    def __init__(self, *args, parsed_response=None, **kwargs):
+        # Requests exceptions support passing in the response.
+        # This adds support for passing the parsed response.
+        self.parsed_response = parsed_response
+        super().__init__(*args, **kwargs)
+
+
+class TransactionDeclinedError(ResponseError):
+    """
+    Transaction was declined. Used if retrying is
+    indeterminate.
+    """
+
+
+class TransactionDeclinedDuplicateError(TransactionDeclinedError):
+    """
+    Transaction was declined due to being a duplicate transaction.
+    """
+
+
+class TransactionDeclinedNotRetryableError(TransactionDeclinedError):
+    """
+    Transaction was declined and should not be retried due
+    to the nature of the decline type.
+    """
+
+
+class TransactionDeclinedRetryableError(TransactionDeclinedError):
+    """
+    Transaction was declined and should be retried,
+    specifically suggested by the code.
+    """
+
+
+class TransactionDeclinedProcessingError(TransactionDeclinedError):
+    """
+    Transaction failed due to a processor or gateway error.
+    """
+
+
+class RateLimitError(TransactionDeclinedProcessingError):
+    """
+    Base for any rate limit being exceeded.
+    These can be trigger from the HTTP status or from the
+    parsed response data. To keep things simple, even
+    the HTTP version inherits from ResponseError.
+    """
+
+
+class SystemWideRateLimitError(RateLimitError, HTTPError):
+    """Raised when the rate limit across all APIs exceeded"""
+
+
+class APIRateLimitError(RateLimitError):
+    """Raised when the rate limit for a single API is exceeded"""

--- a/src/nmigate/response_codes.py
+++ b/src/nmigate/response_codes.py
@@ -1,0 +1,105 @@
+# From:
+# https://docs.nmi.dev/reference/response-codes
+
+Transaction = (
+    (100, "Transaction was approved"),
+    (200, "Transaction was declined by processor"),
+    (201, "Do not honor"),
+    (202, "Insufficient funds"),
+    (203, "Over limit"),
+    (204, "Transaction not allowed"),
+    (220, "Incorrect payment information"),
+    (221, "No such card issuer"),
+    (222, "No card number on file with issuer"),
+    (223, "Expired card"),
+    (224, "Invalid expiration date"),
+    (225, "Invalid card security code"),
+    (226, "Invalid PIN"),
+    (240, "Call issuer for further information"),
+    (250, "Pick up card"),
+    (251, "Lost card"),
+    (252, "Stolen card"),
+    (253, "Fraudulent card"),
+    (260, "Declined with further instructions available (See response text)"),
+    (261, "Declined-Stop all recurring payments"),
+    (262, "Declined-Stop this recurring program"),
+    (263, "Declined-Update cardholder data available"),
+    (264, "Declined-Retry in a few days"),
+    (300, "Transaction was rejected by gateway"),
+    (301, "Too many requests (API)"),
+    (400, "Transaction error returned by processor"),
+    (410, "Invalid merchant configuration"),
+    (411, "Merchant account is inactive"),
+    (420, "Communication error"),
+    (421, "Communication error with issuer"),
+    (430, "Duplicate transaction at processor"),
+    (440, "Processor format error"),
+    (441, "Invalid transaction information"),
+    (460, "Processor feature not available"),
+    (461, "Unsupported card type"),
+)
+
+# These should generally be ones that can be retried without changing anything
+# after an appropriate delay (ie, at least a day for most).
+# Other declines may also be retryable if auto-card update happens, etc.
+retryable_failure_response_codes = (202, 203, 264, 420, 421)
+
+# These should not be retried without changing something.
+# Does not include "normal" declines, only things known to be non-retryable
+# like fraud/lost/stolen card or unsupport card. Also includes the "stop recurring"
+# decline codes.
+non_retryable_failure_response_codes = (250, 251, 252, 253, 261, 262, 461)
+
+# These are issues with the gateway or processor.
+processing_error_response_codes = (300, 400, 410, 411, 420, 421, 440, 441, 460)
+duplicate_transaction_response_code = 430
+rate_limit_error_response_code = 301
+approved_response_code = 100
+
+Avs = (
+    ("X", "Exact match, 9-character numeric ZIP"),
+    ("Y", "Exact match, 5-character numeric ZIP"),
+    ("D", "Exact match, 5-character numeric ZIP"),
+    ("M", "Exact match, 5-character numeric ZIP"),
+    ("2", "Exact match, 5-character numeric ZIP, customer name"),
+    ("6", "Exact match, 5-character numeric ZIP, customer name"),
+    ("A", "Address match only"),
+    ("B", "Address match only"),
+    ("3", "Address, customer name match only"),
+    ("7", "Address, customer name match only"),
+    ("W", "9-character numeric ZIP match only"),
+    ("Z", "5-character ZIP match only"),
+    ("P", "5-character ZIP match only"),
+    ("L", "5-character ZIP match only"),
+    ("1", "5-character ZIP, customer name match only"),
+    ("5", "5-character ZIP, customer name match only"),
+    ("N", "No address or ZIP match only"),
+    ("C", "No address or ZIP match only"),
+    ("4", "No address or ZIP or customer name match only"),
+    ("8", "No address or ZIP or customer name match only"),
+    ("U", "Address unavailable"),
+    ("G", "Non-U.S. issuer does not participate"),
+    ("I", "Non-U.S. issuer does not participate"),
+    ("R", "Issuer system unavailable"),
+    ("E", "Not a mail/phone order"),
+    ("S", "Service not supported"),
+    ("0", "AVS not available"),
+    ("O", "AVS not available"),
+    ("B", "AVS not available"),
+)
+
+
+Cvv = (
+    ("M", "CVV2/CVC2 match"),
+    ("N", "CVV2/CVC2 no match"),
+    ("P", "Not processed"),
+    ("S", "Merchant has indicated that CVV2/CVC2 is not present on card"),
+    ("U", "Issuer is not certified and/or has not provided Visa encryption keys"),
+)
+
+Response = (
+    (0, ""),
+    (1, "approved"),
+    (2, "declined"),
+    (3, "error"),
+)

--- a/src/nmigate/utils.py
+++ b/src/nmigate/utils.py
@@ -1,0 +1,9 @@
+import calendar
+from datetime import date, datetime
+
+
+def card_expiration_as_date(mmyy):
+    """Return a date for the last day of the mo/yr (ints)."""
+    dt = datetime.strptime(mmyy, "%m%y")
+    __, exp_day = calendar.monthrange(dt.month, dt.year)
+    return date(dt.year, dt.month, exp_day)


### PR DESCRIPTION
Expand response handling to detect and raise any issues that occur with the connection (wraps requests exceptions) or errors/declines/rate limits/duplicates in the response data.

Normalize/deserialize some response values expected.
Revert UUIDs to shorter "hex" variant (no hyphens), being rejected as too long with hyphens.
