### PR TITLE
Fix cc_exp unserializing to date

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nmigate"
-version = "0.0.23"
+version = "0.0.24"
 authors = [
   { name="Gustavo", email="gustavo.gordillo.giron@gmail.com" },
 ]

--- a/src/nmigate/utils.py
+++ b/src/nmigate/utils.py
@@ -5,5 +5,5 @@ from datetime import date, datetime
 def card_expiration_as_date(mmyy):
     """Return a date for the last day of the mo/yr (ints)."""
     dt = datetime.strptime(mmyy, "%m%y")
-    __, exp_day = calendar.monthrange(dt.month, dt.year)
+    __, exp_day = calendar.monthrange(dt.year, dt.month)
     return date(dt.year, dt.month, exp_day)


### PR DESCRIPTION
Accidentally reversed the params to monthrange. Should really add (working) test coverage.