### PR TITLE
Fix deserializing of response that contains "+".

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nmigate"
-version = "0.0.27"
+version = "0.0.28"
 authors = [
   { name="Gustavo", email="gustavo.gordillo.giron@gmail.com" },
 ]


### PR DESCRIPTION
`parse_qs/l` will convert `+` to a space by default, so have to pre-process it to % encoded version first. Kind of hacky. :(
Also added some handling to standardize the cc_type to lowercase, and all variants of Amex as "amex" (the query API appears to return a different form).