### PR TITLE
Add validating create method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nmigate"
-version = "0.0.35"
+version = "0.0.37"
 authors = [
   { name="Gustavo", email="gustavo.gordillo.giron@gmail.com" },
 ]

--- a/src/nmigate/customer/customer_vault.py
+++ b/src/nmigate/customer/customer_vault.py
@@ -192,6 +192,39 @@ class CustomerVault(Nmi):
             **extra,
         )
 
+    def validate_and_create(
+        self,
+        payment_token,
+        amount,
+        billing_info,
+        ip_address="",
+        # Generated if not passed. Do not pass existing.
+        billing_id="",
+        order_id="",
+        order_description="",
+        merchant_defined_fields=None,
+        **extra,
+    ):
+        """
+        Create and validate a new card in the vault.
+        Will create a new customer as well
+        if no customer_id is set on the instance.
+        """
+        if merchant_defined_fields:
+            extra.update(normalize_merchant_defined_fields(merchant_defined_fields))
+
+        return self._create(
+            payment_token,
+            billing_info,
+            ip_address=ip_address,
+            trans_type="validate",
+            amount=None,
+            billing_id=billing_id,
+            order_id=order_id,
+            order_description=order_description,
+            **extra,
+        )
+
     def charge(
         self,
         amount,


### PR DESCRIPTION
Add option to only validate only when creating new card and/or customer, for use mainly with adding a new credit card for CoF.