### PR TITLE
Add basic proxy support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nmigate"
-version = "0.0.37"
+version = "0.0.38"
 authors = [
   { name="Gustavo", email="gustavo.gordillo.giron@gmail.com" },
 ]


### PR DESCRIPTION
hotfix to allow passing through proxy settings to the underlying requests lib.
Enabling is a separate setting from the proxy config to allow easy system-wide configuration of the proxy settings while enabling or not can be done at each use of the client (without having to know the config info).